### PR TITLE
Refreshes the library to be up-to-date.

### DIFF
--- a/LibAndroidCrop/res/values/attrs.xml
+++ b/LibAndroidCrop/res/values/attrs.xml
@@ -5,6 +5,11 @@
     <declare-styleable name="CropImageView">
         <attr name="highlightColor" format="reference|color" />
         <attr name="showThirds" format="boolean" />
+        <attr name="showHandles">
+          <enum name="changing" value="0" />
+          <enum name="always" value="1" />
+          <enum name="never" value="2" />
+        </attr>
     </declare-styleable>
 
 </resources>

--- a/LibAndroidCrop/src/com/soundcloud/android/crop/Crop.java
+++ b/LibAndroidCrop/src/com/soundcloud/android/crop/Crop.java
@@ -1,12 +1,17 @@
 package com.soundcloud.android.crop;
 
+import android.annotation.TargetApi;
 import android.app.Activity;
+import android.app.Fragment;
 import android.content.ActivityNotFoundException;
+import android.content.Context;
 import android.content.Intent;
-import android.graphics.Bitmap;
 import android.net.Uri;
+import android.os.Build;
 import android.provider.MediaStore;
 import android.widget.Toast;
+
+import com.soundcloud.android.crop.util.VisibleForTesting;
 
 /**
  * Builder for crop Intents and utils for handling result
@@ -22,7 +27,6 @@ public class Crop {
         String ASPECT_Y = "aspect_y";
         String MAX_X = "max_x";
         String MAX_Y = "max_y";
-        String GUIDES = "show_guides";
         String ERROR = "error";
     }
 
@@ -90,9 +94,20 @@ public class Crop {
         activity.startActivityForResult(getIntent(activity), REQUEST_CROP);
     }
 
-    //VisibleForTesting
-    Intent getIntent(Activity activity) {
-        cropIntent.setClass(activity, CropImageActivity.class);
+    /**
+     * Send the crop Intent!
+     *
+     * @param context Context
+     * @param fragment Fragment that will receive result
+     */
+    @TargetApi(Build.VERSION_CODES.HONEYCOMB)
+    public void start(Context context, Fragment fragment) {
+        fragment.startActivityForResult(getIntent(context), REQUEST_CROP);
+    }
+
+    @VisibleForTesting
+    Intent getIntent(Context context) {
+        cropIntent.setClass(context, CropImageActivity.class);
         return cropIntent;
     }
 
@@ -116,7 +131,7 @@ public class Crop {
     }
 
     /**
-     *  Utility method that starts an image picker. Often preceded a crop.
+     * Utility method that starts an image picker since that often precedes a crop
      *
      * @param activity Activity that will receive result
      */

--- a/LibAndroidCrop/src/com/soundcloud/android/crop/CropUtil.java
+++ b/LibAndroidCrop/src/com/soundcloud/android/crop/CropUtil.java
@@ -24,7 +24,8 @@ import android.net.Uri;
 import android.os.Handler;
 import android.provider.MediaStore;
 import android.text.TextUtils;
-import android.util.Log;
+
+import com.soundcloud.android.crop.util.Log;
 
 import java.io.Closeable;
 import java.io.File;
@@ -33,9 +34,7 @@ import java.io.IOException;
 /*
  * Modified from original in AOSP.
  */
-class Util {
-
-    public static final String TAG = "android-crop";
+class CropUtil {
 
     private static final String SCHEME_FILE = "file";
     private static final String SCHEME_CONTENT = "content";
@@ -65,7 +64,7 @@ class Util {
                     return ExifInterface.ORIENTATION_UNDEFINED;
             }
         } catch (IOException e) {
-            Log.e(TAG, "Error getting Exif data", e);
+            Log.e("Error getting Exif data", e);
             return 0;
         }
     }
@@ -79,7 +78,7 @@ class Util {
             exifDest.saveAttributes();
             return true;
         } catch (IOException e) {
-            Log.e(TAG, "Error copying Exif data", e);
+            Log.e("Error copying Exif data", e);
             return false;
         }
     }

--- a/LibAndroidCrop/src/com/soundcloud/android/crop/HighlightView.java
+++ b/LibAndroidCrop/src/com/soundcloud/android/crop/HighlightView.java
@@ -16,6 +16,7 @@
 
 package com.soundcloud.android.crop;
 
+import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.res.TypedArray;
 import android.graphics.Canvas;
@@ -26,6 +27,7 @@ import android.graphics.Path;
 import android.graphics.Rect;
 import android.graphics.RectF;
 import android.graphics.Region;
+import android.os.Build;
 import android.util.TypedValue;
 import android.view.View;
 
@@ -34,7 +36,7 @@ import android.view.View;
  *
  * This class is used to display a highlighted cropping rectangle
  * overlayed on the image. There are two coordinate spaces in use. One is
- * image, another is screen. computeLayout() uses mMatrix to map from image
+ * image, another is screen. computeLayout() uses matrix to map from image
  * space to screen space.
  */
 class HighlightView {
@@ -51,30 +53,31 @@ class HighlightView {
     private static final float OUTLINE_DP = 2f;
 
     enum ModifyMode { None, Move, Grow }
+    enum HandleMode { Changing, Always, Never }
 
-    RectF mCropRect; // Image space
-    Rect mDrawRect; // Screen space
-    Matrix mMatrix;
-    private RectF mImageRect; // Image space
+    RectF cropRect; // Image space
+    Rect drawRect; // Screen space
+    Matrix matrix;
+    private RectF imageRect; // Image space
 
-    private final Paint mFocusPaint = new Paint();
-    private final Paint mNoFocusPaint = new Paint();
-    private final Paint mOutlinePaint = new Paint();
-    private final Paint mHandlePaint = new Paint();
+    private final Paint outsidePaint = new Paint();
+    private final Paint outlinePaint = new Paint();
+    private final Paint handlePaint = new Paint();
 
-    private View mContext; // View displaying image
-    private boolean mShowThirds;
-    private int mHighlightColor;
+    private View viewContext; // View displaying image
+    private boolean showThirds;
+    private int highlightColor;
 
-    private ModifyMode mMode = ModifyMode.None;
-    private boolean mMaintainAspectRatio;
-    private float mInitialAspectRatio;
-    private float mHandleRadius;
-    private float mOutlineWidth;
-    private boolean mIsFocused;
+    private ModifyMode modifyMode = ModifyMode.None;
+    private HandleMode handleMode = HandleMode.Changing;
+    private boolean maintainAspectRatio;
+    private float initialAspectRatio;
+    private float handleRadius;
+    private float outlineWidth;
+    private boolean isFocused;
 
     public HighlightView(View context) {
-        mContext = context;
+        viewContext = context;
         initStyles(context.getContext());
     }
 
@@ -83,100 +86,133 @@ class HighlightView {
         context.getTheme().resolveAttribute(R.attr.cropImageStyle, outValue, true);
         TypedArray attributes = context.obtainStyledAttributes(outValue.resourceId, R.styleable.CropImageView);
         try {
-            mShowThirds = attributes.getBoolean(R.styleable.CropImageView_showThirds, false);
-            mHighlightColor = attributes.getColor(R.styleable.CropImageView_highlightColor,
+            showThirds = attributes.getBoolean(R.styleable.CropImageView_showThirds, false);
+            highlightColor = attributes.getColor(R.styleable.CropImageView_highlightColor,
                     DEFAULT_HIGHLIGHT_COLOR);
+            handleMode = HandleMode.values()[attributes.getInt(R.styleable.CropImageView_showHandles, 0)];
         } finally {
             attributes.recycle();
         }
     }
 
     public void setup(Matrix m, Rect imageRect, RectF cropRect, boolean maintainAspectRatio) {
-        mMatrix = new Matrix(m);
+        matrix = new Matrix(m);
 
-        mCropRect = cropRect;
-        mImageRect = new RectF(imageRect);
-        mMaintainAspectRatio = maintainAspectRatio;
+        this.cropRect = cropRect;
+        this.imageRect = new RectF(imageRect);
+        this.maintainAspectRatio = maintainAspectRatio;
 
-        mInitialAspectRatio = mCropRect.width() / mCropRect.height();
-        mDrawRect = computeLayout();
+        initialAspectRatio = this.cropRect.width() / this.cropRect.height();
+        drawRect = computeLayout();
 
-        mFocusPaint.setARGB(125, 50, 50, 50);
-        mNoFocusPaint.setARGB(125, 50, 50, 50);
-        mOutlinePaint.setStyle(Paint.Style.STROKE);
-        mOutlinePaint.setAntiAlias(true);
-        mOutlineWidth = dpToPx(OUTLINE_DP);
+        outsidePaint.setARGB(125, 50, 50, 50);
+        outlinePaint.setStyle(Paint.Style.STROKE);
+        outlinePaint.setAntiAlias(true);
+        outlineWidth = dpToPx(OUTLINE_DP);
 
-        mHandlePaint.setColor(mHighlightColor);
-        mHandlePaint.setStyle(Paint.Style.FILL);
-        mHandlePaint.setAntiAlias(true);
-        mHandleRadius = dpToPx(HANDLE_RADIUS_DP);
+        handlePaint.setColor(highlightColor);
+        handlePaint.setStyle(Paint.Style.FILL);
+        handlePaint.setAntiAlias(true);
+        handleRadius = dpToPx(HANDLE_RADIUS_DP);
 
-        mMode = ModifyMode.None;
+        modifyMode = ModifyMode.None;
     }
 
     private float dpToPx(float dp) {
-        return dp * mContext.getResources().getDisplayMetrics().density;
+        return dp * viewContext.getResources().getDisplayMetrics().density;
     }
 
     protected void draw(Canvas canvas) {
         canvas.save();
         Path path = new Path();
-        mOutlinePaint.setStrokeWidth(mOutlineWidth);
+        outlinePaint.setStrokeWidth(outlineWidth);
         if (!hasFocus()) {
-            mOutlinePaint.setColor(Color.BLACK);
-            canvas.drawRect(mDrawRect, mOutlinePaint);
+            outlinePaint.setColor(Color.BLACK);
+            canvas.drawRect(drawRect, outlinePaint);
         } else {
             Rect viewDrawingRect = new Rect();
-            mContext.getDrawingRect(viewDrawingRect);
+            viewContext.getDrawingRect(viewDrawingRect);
 
-            path.addRect(new RectF(mDrawRect), Path.Direction.CW);
-            mOutlinePaint.setColor(mHighlightColor);
+            path.addRect(new RectF(drawRect), Path.Direction.CW);
+            outlinePaint.setColor(highlightColor);
 
-            canvas.clipPath(path, Region.Op.DIFFERENCE);
-            canvas.drawRect(viewDrawingRect, hasFocus() ? mFocusPaint : mNoFocusPaint);
+            if (isClipPathSupported(canvas)) {
+                canvas.clipPath(path, Region.Op.DIFFERENCE);
+                canvas.drawRect(viewDrawingRect, outsidePaint);
+            } else {
+                drawOutsideFallback(canvas);
+            }
 
             canvas.restore();
-            canvas.drawPath(path, mOutlinePaint);
+            canvas.drawPath(path, outlinePaint);
 
-            if (mShowThirds) {
+            if (showThirds) {
                 drawThirds(canvas);
             }
-            if (mMode == ModifyMode.Grow) {
+
+            if (handleMode == HandleMode.Always ||
+                    (handleMode == HandleMode.Changing && modifyMode == ModifyMode.Grow)) {
                 drawHandles(canvas);
             }
         }
     }
 
-    private void drawHandles(Canvas canvas) {
-        int xMiddle = mDrawRect.left + ((mDrawRect.right  - mDrawRect.left) / 2);
-        int yMiddle = mDrawRect.top + ((mDrawRect.bottom - mDrawRect.top) / 2);
+    /*
+     * Fall back to naive method for darkening outside crop area
+     */
+    private void drawOutsideFallback(Canvas canvas) {
+        canvas.drawRect(0, 0, canvas.getWidth(), drawRect.top, outsidePaint);
+        canvas.drawRect(0, drawRect.bottom, canvas.getWidth(), canvas.getHeight(), outsidePaint);
+        canvas.drawRect(0, drawRect.top, drawRect.left, drawRect.bottom, outsidePaint);
+        canvas.drawRect(drawRect.right, drawRect.top, canvas.getWidth(), drawRect.bottom, outsidePaint);
+    }
 
-        canvas.drawCircle(mDrawRect.left, yMiddle, mHandleRadius, mHandlePaint);
-        canvas.drawCircle(xMiddle, mDrawRect.top, mHandleRadius, mHandlePaint);
-        canvas.drawCircle(mDrawRect.right, yMiddle, mHandleRadius, mHandlePaint);
-        canvas.drawCircle(xMiddle, mDrawRect.bottom, mHandleRadius, mHandlePaint);
+    /*
+     * Clip path is broken, unreliable or not supported on:
+     * - JellyBean MR1
+     * - ICS & ICS MR1 with hardware acceleration turned on
+     */
+    @SuppressLint("NewApi")
+    private boolean isClipPathSupported(Canvas canvas) {
+        if (Build.VERSION.SDK_INT == Build.VERSION_CODES.JELLY_BEAN_MR1) {
+            return false;
+        } else if ((Build.VERSION.SDK_INT < Build.VERSION_CODES.ICE_CREAM_SANDWICH)
+            || Build.VERSION.SDK_INT > Build.VERSION_CODES.ICE_CREAM_SANDWICH_MR1) {
+            return true;
+        } else {
+            return !canvas.isHardwareAccelerated();
+        }
+    }
+
+    private void drawHandles(Canvas canvas) {
+        int xMiddle = drawRect.left + ((drawRect.right  - drawRect.left) / 2);
+        int yMiddle = drawRect.top + ((drawRect.bottom - drawRect.top) / 2);
+
+        canvas.drawCircle(drawRect.left, yMiddle, handleRadius, handlePaint);
+        canvas.drawCircle(xMiddle, drawRect.top, handleRadius, handlePaint);
+        canvas.drawCircle(drawRect.right, yMiddle, handleRadius, handlePaint);
+        canvas.drawCircle(xMiddle, drawRect.bottom, handleRadius, handlePaint);
     }
 
     private void drawThirds(Canvas canvas) {
-        mOutlinePaint.setStrokeWidth(1);
-        float xThird = (mDrawRect.right - mDrawRect.left) / 3;
-        float yThird = (mDrawRect.bottom - mDrawRect.top) / 3;
+        outlinePaint.setStrokeWidth(1);
+        float xThird = (drawRect.right - drawRect.left) / 3;
+        float yThird = (drawRect.bottom - drawRect.top) / 3;
         
-        canvas.drawLine(mDrawRect.left + xThird, mDrawRect.top,
-                mDrawRect.left + xThird, mDrawRect.bottom, mOutlinePaint);
-        canvas.drawLine(mDrawRect.left + xThird * 2, mDrawRect.top,
-                mDrawRect.left + xThird * 2, mDrawRect.bottom, mOutlinePaint);
-        canvas.drawLine(mDrawRect.left, mDrawRect.top + yThird,
-                mDrawRect.right, mDrawRect.top + yThird, mOutlinePaint);
-        canvas.drawLine(mDrawRect.left, mDrawRect.top + yThird * 2,
-                mDrawRect.right, mDrawRect.top + yThird * 2, mOutlinePaint);
+        canvas.drawLine(drawRect.left + xThird, drawRect.top,
+                drawRect.left + xThird, drawRect.bottom, outlinePaint);
+        canvas.drawLine(drawRect.left + xThird * 2, drawRect.top,
+                drawRect.left + xThird * 2, drawRect.bottom, outlinePaint);
+        canvas.drawLine(drawRect.left, drawRect.top + yThird,
+                drawRect.right, drawRect.top + yThird, outlinePaint);
+        canvas.drawLine(drawRect.left, drawRect.top + yThird * 2,
+                drawRect.right, drawRect.top + yThird * 2, outlinePaint);
     }
 
     public void setMode(ModifyMode mode) {
-        if (mode != mMode) {
-            mMode = mode;
-            mContext.invalidate();
+        if (mode != modifyMode) {
+            modifyMode = mode;
+            viewContext.invalidate();
         }
     }
 
@@ -220,8 +256,8 @@ class HighlightView {
         Rect r = computeLayout();
         if (edge == MOVE) {
             // Convert to image space before sending to moveBy()
-            moveBy(dx * (mCropRect.width() / r.width()),
-                   dy * (mCropRect.height() / r.height()));
+            moveBy(dx * (cropRect.width() / r.width()),
+                   dy * (cropRect.height() / r.height()));
         } else {
             if (((GROW_LEFT_EDGE | GROW_RIGHT_EDGE) & edge) == 0) {
                 dx = 0;
@@ -232,8 +268,8 @@ class HighlightView {
             }
 
             // Convert to image space before sending to growBy()
-            float xDelta = dx * (mCropRect.width() / r.width());
-            float yDelta = dy * (mCropRect.height() / r.height());
+            float xDelta = dx * (cropRect.width() / r.width());
+            float yDelta = dy * (cropRect.height() / r.height());
             growBy((((edge & GROW_LEFT_EDGE) != 0) ? -1 : 1) * xDelta,
                     (((edge & GROW_TOP_EDGE) != 0) ? -1 : 1) * yDelta);
         }
@@ -241,49 +277,49 @@ class HighlightView {
 
     // Grows the cropping rectangle by (dx, dy) in image space
     void moveBy(float dx, float dy) {
-        Rect invalRect = new Rect(mDrawRect);
+        Rect invalRect = new Rect(drawRect);
 
-        mCropRect.offset(dx, dy);
+        cropRect.offset(dx, dy);
 
         // Put the cropping rectangle inside image rectangle
-        mCropRect.offset(
-                Math.max(0, mImageRect.left - mCropRect.left),
-                Math.max(0, mImageRect.top  - mCropRect.top));
+        cropRect.offset(
+                Math.max(0, imageRect.left - cropRect.left),
+                Math.max(0, imageRect.top  - cropRect.top));
 
-        mCropRect.offset(
-                Math.min(0, mImageRect.right  - mCropRect.right),
-                Math.min(0, mImageRect.bottom - mCropRect.bottom));
+        cropRect.offset(
+                Math.min(0, imageRect.right  - cropRect.right),
+                Math.min(0, imageRect.bottom - cropRect.bottom));
 
-        mDrawRect = computeLayout();
-        invalRect.union(mDrawRect);
-        invalRect.inset(-10, -10);
-        mContext.invalidate(invalRect);
+        drawRect = computeLayout();
+        invalRect.union(drawRect);
+        invalRect.inset(-(int) handleRadius, -(int) handleRadius);
+        viewContext.invalidate(invalRect);
     }
 
     // Grows the cropping rectangle by (dx, dy) in image space.
     void growBy(float dx, float dy) {
-        if (mMaintainAspectRatio) {
+        if (maintainAspectRatio) {
             if (dx != 0) {
-                dy = dx / mInitialAspectRatio;
+                dy = dx / initialAspectRatio;
             } else if (dy != 0) {
-                dx = dy * mInitialAspectRatio;
+                dx = dy * initialAspectRatio;
             }
         }
 
         // Don't let the cropping rectangle grow too fast.
         // Grow at most half of the difference between the image rectangle and
         // the cropping rectangle.
-        RectF r = new RectF(mCropRect);
-        if (dx > 0F && r.width() + 2 * dx > mImageRect.width()) {
-            dx = (mImageRect.width() - r.width()) / 2F;
-            if (mMaintainAspectRatio) {
-                dy = dx / mInitialAspectRatio;
+        RectF r = new RectF(cropRect);
+        if (dx > 0F && r.width() + 2 * dx > imageRect.width()) {
+            dx = (imageRect.width() - r.width()) / 2F;
+            if (maintainAspectRatio) {
+                dy = dx / initialAspectRatio;
             }
         }
-        if (dy > 0F && r.height() + 2 * dy > mImageRect.height()) {
-            dy = (mImageRect.height() - r.height()) / 2F;
-            if (mMaintainAspectRatio) {
-                dx = dy * mInitialAspectRatio;
+        if (dy > 0F && r.height() + 2 * dy > imageRect.height()) {
+            dy = (imageRect.height() - r.height()) / 2F;
+            if (maintainAspectRatio) {
+                dx = dy * initialAspectRatio;
             }
         }
 
@@ -294,55 +330,55 @@ class HighlightView {
         if (r.width() < widthCap) {
             r.inset(-(widthCap - r.width()) / 2F, 0F);
         }
-        float heightCap = mMaintainAspectRatio
-                ? (widthCap / mInitialAspectRatio)
+        float heightCap = maintainAspectRatio
+                ? (widthCap / initialAspectRatio)
                 : widthCap;
         if (r.height() < heightCap) {
             r.inset(0F, -(heightCap - r.height()) / 2F);
         }
 
         // Put the cropping rectangle inside the image rectangle
-        if (r.left < mImageRect.left) {
-            r.offset(mImageRect.left - r.left, 0F);
-        } else if (r.right > mImageRect.right) {
-            r.offset(-(r.right - mImageRect.right), 0F);
+        if (r.left < imageRect.left) {
+            r.offset(imageRect.left - r.left, 0F);
+        } else if (r.right > imageRect.right) {
+            r.offset(-(r.right - imageRect.right), 0F);
         }
-        if (r.top < mImageRect.top) {
-            r.offset(0F, mImageRect.top - r.top);
-        } else if (r.bottom > mImageRect.bottom) {
-            r.offset(0F, -(r.bottom - mImageRect.bottom));
+        if (r.top < imageRect.top) {
+            r.offset(0F, imageRect.top - r.top);
+        } else if (r.bottom > imageRect.bottom) {
+            r.offset(0F, -(r.bottom - imageRect.bottom));
         }
 
-        mCropRect.set(r);
-        mDrawRect = computeLayout();
-        mContext.invalidate();
+        cropRect.set(r);
+        drawRect = computeLayout();
+        viewContext.invalidate();
     }
 
-    // Returns the cropping rectangle in image space
-    public Rect getCropRect() {
-        return new Rect((int) mCropRect.left, (int) mCropRect.top,
-                        (int) mCropRect.right, (int) mCropRect.bottom);
+    // Returns the cropping rectangle in image space with specified scale
+    public Rect getScaledCropRect(float scale) {
+        return new Rect((int) (cropRect.left * scale), (int) (cropRect.top * scale),
+                (int) (cropRect.right * scale), (int) (cropRect.bottom * scale));
     }
 
     // Maps the cropping rectangle from image space to screen space
     private Rect computeLayout() {
-        RectF r = new RectF(mCropRect.left, mCropRect.top,
-                            mCropRect.right, mCropRect.bottom);
-        mMatrix.mapRect(r);
+        RectF r = new RectF(cropRect.left, cropRect.top,
+                            cropRect.right, cropRect.bottom);
+        matrix.mapRect(r);
         return new Rect(Math.round(r.left), Math.round(r.top),
                         Math.round(r.right), Math.round(r.bottom));
     }
 
     public void invalidate() {
-        mDrawRect = computeLayout();
+        drawRect = computeLayout();
     }
 
     public boolean hasFocus() {
-        return mIsFocused;
+        return isFocused;
     }
 
     public void setFocus(boolean isFocused) {
-        mIsFocused = isFocused;
+        this.isFocused = isFocused;
     }
 
 }

--- a/LibAndroidCrop/src/com/soundcloud/android/crop/MonitoredActivity.java
+++ b/LibAndroidCrop/src/com/soundcloud/android/crop/MonitoredActivity.java
@@ -26,7 +26,7 @@ import java.util.ArrayList;
  */
 abstract class MonitoredActivity extends Activity {
 
-    private final ArrayList<LifeCycleListener> mListeners = new ArrayList<LifeCycleListener>();
+    private final ArrayList<LifeCycleListener> listeners = new ArrayList<LifeCycleListener>();
 
     public static interface LifeCycleListener {
         public void onActivityCreated(MonitoredActivity activity);
@@ -43,18 +43,18 @@ abstract class MonitoredActivity extends Activity {
     }
 
     public void addLifeCycleListener(LifeCycleListener listener) {
-        if (mListeners.contains(listener)) return;
-        mListeners.add(listener);
+        if (listeners.contains(listener)) return;
+        listeners.add(listener);
     }
 
     public void removeLifeCycleListener(LifeCycleListener listener) {
-        mListeners.remove(listener);
+        listeners.remove(listener);
     }
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        for (LifeCycleListener listener : mListeners) {
+        for (LifeCycleListener listener : listeners) {
             listener.onActivityCreated(this);
         }
     }
@@ -62,7 +62,7 @@ abstract class MonitoredActivity extends Activity {
     @Override
     protected void onDestroy() {
         super.onDestroy();
-        for (LifeCycleListener listener : mListeners) {
+        for (LifeCycleListener listener : listeners) {
             listener.onActivityDestroyed(this);
         }
     }
@@ -70,7 +70,7 @@ abstract class MonitoredActivity extends Activity {
     @Override
     protected void onStart() {
         super.onStart();
-        for (LifeCycleListener listener : mListeners) {
+        for (LifeCycleListener listener : listeners) {
             listener.onActivityStarted(this);
         }
     }
@@ -78,7 +78,7 @@ abstract class MonitoredActivity extends Activity {
     @Override
     protected void onStop() {
         super.onStop();
-        for (LifeCycleListener listener : mListeners) {
+        for (LifeCycleListener listener : listeners) {
             listener.onActivityStopped(this);
         }
     }

--- a/LibAndroidCrop/src/com/soundcloud/android/crop/RotateBitmap.java
+++ b/LibAndroidCrop/src/com/soundcloud/android/crop/RotateBitmap.java
@@ -24,72 +24,72 @@ import android.graphics.Matrix;
  */
 class RotateBitmap {
 
-    private Bitmap mBitmap;
-    private int mRotation;
+    private Bitmap bitmap;
+    private int rotation;
 
     public RotateBitmap(Bitmap bitmap, int rotation) {
-        mBitmap = bitmap;
-        mRotation = rotation % 360;
+        this.bitmap = bitmap;
+        this.rotation = rotation % 360;
     }
 
     public void setRotation(int rotation) {
-        mRotation = rotation;
+        this.rotation = rotation;
     }
 
     public int getRotation() {
-        return mRotation;
+        return rotation;
     }
 
     public Bitmap getBitmap() {
-        return mBitmap;
+        return bitmap;
     }
 
     public void setBitmap(Bitmap bitmap) {
-        mBitmap = bitmap;
+        this.bitmap = bitmap;
     }
 
     public Matrix getRotateMatrix() {
         // By default this is an identity matrix
         Matrix matrix = new Matrix();
-        if (mBitmap != null && mRotation != 0) {
+        if (bitmap != null && rotation != 0) {
             // We want to do the rotation at origin, but since the bounding
             // rectangle will be changed after rotation, so the delta values
             // are based on old & new width/height respectively.
-            int cx = mBitmap.getWidth() / 2;
-            int cy = mBitmap.getHeight() / 2;
+            int cx = bitmap.getWidth() / 2;
+            int cy = bitmap.getHeight() / 2;
             matrix.preTranslate(-cx, -cy);
-            matrix.postRotate(mRotation);
+            matrix.postRotate(rotation);
             matrix.postTranslate(getWidth() / 2, getHeight() / 2);
         }
         return matrix;
     }
 
     public boolean isOrientationChanged() {
-        return (mRotation / 90) % 2 != 0;
+        return (rotation / 90) % 2 != 0;
     }
 
     public int getHeight() {
-        if (mBitmap == null) return 0;
+        if (bitmap == null) return 0;
         if (isOrientationChanged()) {
-            return mBitmap.getWidth();
+            return bitmap.getWidth();
         } else {
-            return mBitmap.getHeight();
+            return bitmap.getHeight();
         }
     }
 
     public int getWidth() {
-        if (mBitmap == null) return 0;
+        if (bitmap == null) return 0;
         if (isOrientationChanged()) {
-            return mBitmap.getHeight();
+            return bitmap.getHeight();
         } else {
-            return mBitmap.getWidth();
+            return bitmap.getWidth();
         }
     }
 
     public void recycle() {
-        if (mBitmap != null) {
-            mBitmap.recycle();
-            mBitmap = null;
+        if (bitmap != null) {
+            bitmap.recycle();
+            bitmap = null;
         }
     }
 }

--- a/LibAndroidCrop/src/com/soundcloud/android/crop/util/Log.java
+++ b/LibAndroidCrop/src/com/soundcloud/android/crop/util/Log.java
@@ -1,0 +1,15 @@
+package com.soundcloud.android.crop.util;
+
+public class Log {
+
+    private static final String TAG = "android-crop";
+
+    public static final void e(String msg) {
+        android.util.Log.e(TAG, msg);
+    }
+
+    public static final void e(String msg, Throwable e) {
+        android.util.Log.e(TAG, msg, e);
+    }
+
+}

--- a/LibAndroidCrop/src/com/soundcloud/android/crop/util/VisibleForTesting.java
+++ b/LibAndroidCrop/src/com/soundcloud/android/crop/util/VisibleForTesting.java
@@ -1,0 +1,12 @@
+package com.soundcloud.android.crop.util;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Documented
+@Retention(RetentionPolicy.SOURCE)
+@Target({ElementType.CONSTRUCTOR, ElementType.FIELD, ElementType.METHOD, ElementType.TYPE})
+public @interface VisibleForTesting {}


### PR DESCRIPTION
Hi!

Thanks so much for making this easier for Eclipse users with your project!

I was getting a crasher on the Galaxy when using a photo taken from the back-facing camera due to out-of-memory issues -- turns out the library this is wrapping around is out-of-date, and newer versions have better checks and scaling to prevent this from being a problem.

This pull request updates the sources to what's at HEAD on the `android-crop` library. Hope this helps, let me know if you'd like me to do anything with it :)

-Pablo
